### PR TITLE
[Fix] filter non-text files for summarizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ venv/
 # Ignore example output files
 organized_folder/
 operation_log.txt
+node_modules/
+AGENTS.md

--- a/data_processing_common.py
+++ b/data_processing_common.py
@@ -1,0 +1,17 @@
+from data_processing_common_consolidated import (
+    sanitize_filename,
+    get_file_size_category,
+    process_files_by_date,
+    process_files_by_type,
+    compute_operations,
+    execute_operations,
+)
+
+__all__ = [
+    "sanitize_filename",
+    "get_file_size_category",
+    "process_files_by_date",
+    "process_files_by_type",
+    "compute_operations",
+    "execute_operations",
+]

--- a/file_summarizer.py
+++ b/file_summarizer.py
@@ -1,0 +1,72 @@
+import argparse
+from typing import Dict, List
+
+from file_utils import (
+    collect_file_paths,
+    read_file_data,
+    separate_files_by_type,
+)
+from text_data_processing import summarize_text_content
+import os
+
+
+def summarize_files(file_paths: List[str], text_inference) -> Dict[str, str]:
+    """Return summaries for given file paths.
+
+    Args:
+        file_paths: List of files to summarize.
+        text_inference: Inference object with a ``create_completion`` method.
+
+    Returns:
+        Mapping of file path to generated summary text.
+    """
+    summaries: Dict[str, str] = {}
+    _, text_files = separate_files_by_type(file_paths)
+    for path in text_files:
+        text = read_file_data(path)
+        if text:
+            summaries[path] = summarize_text_content(text, text_inference)
+    return summaries
+
+
+def summarize_path(path: str, text_inference) -> Dict[str, str]:
+    """Summarize a single file or all files in a directory.
+
+    Args:
+        path: Path to a file or directory to summarize.
+        text_inference: Inference object with a ``create_completion`` method.
+
+    Returns:
+        A dictionary mapping file paths to their summaries.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    file_paths = collect_file_paths(path)
+    return summarize_files(file_paths, text_inference)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Batch summarize documents")
+    parser.add_argument("path", help="File or directory to summarize")
+    args = parser.parse_args()
+
+    from nexa.gguf import NexaTextInference
+    from output_filter import filter_specific_output
+
+    model_path_text = "Llama3.2-3B-Instruct:q3_K_M"
+    with filter_specific_output():
+        text_inference = NexaTextInference(
+            model_path=model_path_text,
+            local_path=None,
+            stop_words=[],
+            temperature=0.5,
+            max_new_tokens=3000,
+            top_k=3,
+            top_p=0.3,
+            profiling=False,
+        )
+    for file, summary in summarize_path(args.path, text_inference).items():
+        print(f"\n=== {file} ===\n{summary}\n")

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+)  # noqa: E402
+from file_summarizer import summarize_files, summarize_path  # noqa: E402
+
+
+class FakeInference:
+    def create_completion(self, prompt):
+        return {"choices": [{"text": "test summary"}]}
+
+
+class TestSummarizer(unittest.TestCase):
+    def test_summarize_files(self):
+        test_file = "sample_test.txt"
+        with open(test_file, "w") as f:
+            f.write("This is a sample text file. It has two sentences.")
+
+        summaries = summarize_files([test_file], FakeInference())
+        self.assertIn(test_file, summaries)
+        self.assertEqual(summaries[test_file], "test summary")
+
+        summaries2 = summarize_path(test_file, FakeInference())
+        self.assertIn(test_file, summaries2)
+        self.assertEqual(summaries2[test_file], "test summary")
+
+        os.remove(test_file)
+
+    def test_summarize_path_directory(self):
+        test_dir = "sample_dir"
+        os.makedirs(test_dir, exist_ok=True)
+        file1 = os.path.join(test_dir, "file1.txt")
+        file2 = os.path.join(test_dir, "file2.txt")
+        with open(file1, "w") as f:
+            f.write("Content of file one.")
+        with open(file2, "w") as f:
+            f.write("Content of file two.")
+
+        summaries = summarize_path(test_dir, FakeInference())
+        self.assertIn(file1, summaries)
+        self.assertIn(file2, summaries)
+
+        os.remove(file1)
+        os.remove(file2)
+        os.rmdir(test_dir)
+
+    def test_summarize_path_missing(self):
+        with self.assertRaises(FileNotFoundError):
+            summarize_path("nonexistent.txt", FakeInference())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- skip non-text files when creating summaries

## Testing Done
- `black file_summarizer.py tests/test_summarizer.py data_processing_common.py`
- `flake8 file_summarizer.py tests/test_summarizer.py data_processing_common.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts='' tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_68526bc9fbe88333913b9a0558d363fc

## Summary by Sourcery

Implement a new file_summarizer tool that filters out non-text files, processes text files individually or in bulk via a CLI, handles missing paths gracefully, and include corresponding unit tests and a shared data_processing_common module.

New Features:
- Add a file_summarizer module with CLI support to batch summarize text files

Bug Fixes:
- Skip non-text files when collecting documents to summarize

Enhancements:
- Raise FileNotFoundError for missing paths in summarize_path

Tests:
- Add unit tests for summarize_files and summarize_path covering single files, directories, and missing paths

Chores:
- Introduce data_processing_common to re-export shared file processing utilities