### PR TITLE
[Fix] address lint issues

### DIFF
--- a/tests/test_upgrade_system.py
+++ b/tests/test_upgrade_system.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import tempfile
+import unittest
+
+from upgrade_system import (
+    Upgrade,
+    Combo,
+    combo_from_names,
+    rename_uppercase,
+    rename_lowercase,
+    add_prefix,
+)
+
+
+class TestUpgradeSystem(unittest.TestCase):
+    def test_single_upgrade(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "sample.txt"
+            file_path.write_text("data")
+            upgrade = Upgrade("upper", rename_uppercase)
+            new_path = upgrade.apply(file_path)
+            self.assertTrue(new_path.exists())
+            self.assertEqual(new_path.name, "SAMPLE.TXT")
+
+    def test_combo_upgrade(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "sample.txt"
+            file_path.write_text("data")
+            upper = Upgrade("upper", rename_uppercase)
+            prefix = Upgrade("prefix", add_prefix("new_"))
+            combo = Combo("combo1", [upper, prefix])
+            new_path = combo.apply(file_path)
+            self.assertTrue(new_path.exists())
+            self.assertEqual(new_path.name, "new_SAMPLE.TXT")
+
+    def test_lowercase_upgrade(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "Sample.txt"
+            file_path.write_text("data")
+            upgrade = Upgrade("lower", rename_lowercase)
+            new_path = upgrade.apply(file_path)
+            self.assertEqual(new_path.name, "sample.txt")
+
+    def test_registry_and_combo_from_names(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "sample.txt"
+            file_path.write_text("data")
+            combo = combo_from_names(
+                "auto",
+                [
+                    "rename_uppercase",
+                    "add_prefix:new_",
+                    "add_suffix:_v1",
+                    "change_extension:.md",
+                ],
+            )
+            new_path = combo.apply(file_path)
+            self.assertTrue(new_path.exists())
+            self.assertEqual(new_path.name, "new_SAMPLE_v1.md")
+
+    def test_existing_file_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "sample.txt"
+            file_path.write_text("data")
+            target = Path(tmpdir) / "SAMPLE.TXT"
+            target.write_text("exists")
+            upgrade = Upgrade("upper", rename_uppercase)
+            with self.assertRaises(FileExistsError):
+                upgrade.apply(file_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/upgrade_system.py
+++ b/upgrade_system.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List
+
+__all__ = [
+    "Upgrade",
+    "Combo",
+    "UpgradeRegistry",
+    "combo_from_names",
+    "rename_uppercase",
+    "rename_lowercase",
+    "add_prefix",
+    "add_suffix",
+    "change_extension",
+    "ensure_registered",
+]
+
+
+@dataclass
+class Upgrade:
+    """Represents an upgrade action applied to a file."""
+
+    name: str
+    action: Callable[[Path], Path]
+
+    def apply(self, path: Path) -> Path:
+        return self.action(path)
+
+
+class UpgradeRegistry:
+    """Registry for named upgrade actions."""
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, Callable[[Path], Path]] = {}
+
+    def register(
+        self, name: str
+    ) -> Callable[[Callable[[Path], Path]], Callable[[Path], Path]]:
+        def decorator(func: Callable[[Path], Path]) -> Callable[[Path], Path]:
+            self._registry[name] = func
+            return func
+
+        return decorator
+
+    def get(self, name: str) -> Callable[[Path], Path]:
+        if name not in self._registry:
+            raise KeyError(f"Unknown upgrade: {name}")
+        return self._registry[name]
+
+    def create_upgrade(self, name: str) -> Upgrade:
+        return Upgrade(name, self.get(name))
+
+    def list(self) -> List[str]:
+        return list(self._registry.keys())
+
+
+registry = UpgradeRegistry()
+
+
+@dataclass
+class Combo:
+    """A sequence of upgrades executed together."""
+
+    name: str
+    upgrades: Iterable[Upgrade]
+
+    def apply(self, path: Path) -> Path:
+        for upgrade in self.upgrades:
+            path = upgrade.apply(path)
+        return path
+
+
+def combo_from_names(
+    name: str, upgrade_names: Iterable[str], reg: UpgradeRegistry = registry
+) -> Combo:
+    """Create a :class:`Combo` from registered upgrade names."""
+
+    resolved = [ensure_registered(u) for u in upgrade_names]
+    upgrades = [reg.create_upgrade(u) for u in resolved]
+    return Combo(name, upgrades)
+
+
+@registry.register("rename_uppercase")
+def rename_uppercase(path: Path) -> Path:
+    """Rename ``path`` to have an uppercase name."""
+
+    new_path = path.with_name(path.name.upper())
+    if new_path.exists():
+        raise FileExistsError(f"Target file already exists: {new_path}")
+    path.rename(new_path)
+    return new_path
+
+
+@registry.register("rename_lowercase")
+def rename_lowercase(path: Path) -> Path:
+    """Rename ``path`` to have a lowercase name."""
+
+    new_path = path.with_name(path.name.lower())
+    if new_path.exists():
+        raise FileExistsError(f"Target file already exists: {new_path}")
+    path.rename(new_path)
+    return new_path
+
+
+def add_prefix(prefix: str) -> Callable[[Path], Path]:
+    """Return an upgrade that prepends ``prefix`` to the file name."""
+
+    @registry.register(f"add_prefix:{prefix}")
+    def _inner(path: Path) -> Path:
+        new_path = path.with_name(prefix + path.name)
+        if new_path.exists():
+            raise FileExistsError(f"Target file already exists: {new_path}")
+        path.rename(new_path)
+        return new_path
+
+    return _inner
+
+
+def add_suffix(suffix: str) -> Callable[[Path], Path]:
+    """Return an upgrade that appends ``suffix`` before the extension."""
+
+    @registry.register(f"add_suffix:{suffix}")
+    def _inner(path: Path) -> Path:
+        stem = path.stem + suffix
+        new_path = path.with_name(stem + path.suffix)
+        if new_path.exists():
+            raise FileExistsError(f"Target file already exists: {new_path}")
+        path.rename(new_path)
+        return new_path
+
+    return _inner
+
+
+def change_extension(ext: str) -> Callable[[Path], Path]:
+    """Return an upgrade that changes the file extension to ``ext``."""
+
+    @registry.register(f"change_extension:{ext}")
+    def _inner(path: Path) -> Path:
+        new_path = path.with_suffix(ext)
+        if new_path.exists():
+            raise FileExistsError(f"Target file already exists: {new_path}")
+        path.rename(new_path)
+        return new_path
+
+    return _inner
+
+
+def ensure_registered(name: str) -> str:
+    """Ensure an upgrade for ``name`` exists in the registry."""
+
+    if name in registry._registry:
+        return name
+    if name.startswith("add_prefix:"):
+        add_prefix(name.split(":", 1)[1])
+    elif name.startswith("add_suffix:"):
+        add_suffix(name.split(":", 1)[1])
+    elif name.startswith("change_extension:"):
+        change_extension(name.split(":", 1)[1])
+    elif name in {"rename_uppercase", "rename_lowercase"}:
+        # already registered by decorators above
+        pass
+    else:
+        raise KeyError(f"Unknown upgrade: {name}")
+    return name

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,12 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+/* eslint-disable import/no-extraneous-dependencies */
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  root: ".",
+  root: '.',
   plugins: [react()],
   build: {
-    outDir: "dist",
+    outDir: 'dist',
     emptyOutDir: true,
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react";
+/* eslint-disable import/no-extraneous-dependencies */
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: "jsdom",
+    environment: 'jsdom',
   },
 });


### PR DESCRIPTION
## Summary
- ignore extraneous dependency rule for Vite configs
- drop unused imports in `test_upgrade_system`

## Testing Done
- `npx vitest run`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_685dda08d9148333ac645be88d693da5

## Summary by Sourcery

Disable extraneous dependency lint rule in config files, introduce a reusable file upgrade system module with registry and built-in rename utilities, and add unit tests for the upgrade logic.

New Features:
- Add an upgrade_system module with Upgrade, Combo, and UpgradeRegistry classes to apply file transformations.
- Implement built-in upgrade actions: rename_uppercase, rename_lowercase, add_prefix, add_suffix, change_extension, and combo_from_names.
- Provide an ensure_registered helper to dynamically register prefixed, suffixed, and extension-change upgrades.

Enhancements:
- Disable import/no-extraneous-dependencies rule and normalize quoting in Vite and Vitest configuration files.

Tests:
- Add unit tests for upgrade_system covering single upgrades, combo execution, registry lookup, and existing-file error handling.