### PR TITLE
[Feature] add forensic organizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ venv/
 # Ignore example output files
 organized_folder/
 operation_log.txt
+node_modules/
+AGENTS.md

--- a/data_processing_common.py
+++ b/data_processing_common.py
@@ -1,0 +1,17 @@
+from data_processing_common_consolidated import (
+    sanitize_filename,
+    get_file_size_category,
+    process_files_by_date,
+    process_files_by_type,
+    compute_operations,
+    execute_operations,
+)
+
+__all__ = [
+    "sanitize_filename",
+    "get_file_size_category",
+    "process_files_by_date",
+    "process_files_by_type",
+    "compute_operations",
+    "execute_operations",
+]

--- a/file_summarizer.py
+++ b/file_summarizer.py
@@ -1,0 +1,94 @@
+import argparse
+import json
+from typing import Dict, List
+
+from file_utils import (
+    collect_file_paths,
+    read_file_data,
+    separate_files_by_type,
+)
+from text_data_processing import summarize_text_content
+import os
+
+
+def summarize_files(file_paths: List[str], text_inference) -> Dict[str, str]:
+    """Return summaries for given file paths.
+
+    Args:
+        file_paths: List of files to summarize.
+        text_inference: Inference object with a ``create_completion`` method.
+
+    Returns:
+        Mapping of file path to generated summary text.
+    """
+    summaries: Dict[str, str] = {}
+    _, text_files = separate_files_by_type(file_paths)
+    for path in text_files:
+        text = read_file_data(path)
+        if text:
+            summaries[path] = summarize_text_content(text, text_inference)
+    return summaries
+
+
+def save_summaries(summaries: Dict[str, str], output_path: str) -> None:
+    """Write summaries to a JSON file.
+
+    Args:
+        summaries: Mapping of file paths to summary text.
+        output_path: File path to save JSON summaries.
+    """
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(summaries, f, indent=2, ensure_ascii=False)
+
+
+def summarize_path(path: str, text_inference) -> Dict[str, str]:
+    """Summarize a single file or all files in a directory.
+
+    Args:
+        path: Path to a file or directory to summarize.
+        text_inference: Inference object with a ``create_completion`` method.
+
+    Returns:
+        A dictionary mapping file paths to their summaries.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    file_paths = collect_file_paths(path)
+    return summarize_files(file_paths, text_inference)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Batch summarize documents")
+    parser.add_argument("path", help="File or directory to summarize")
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Optional path to write summaries as JSON",
+        default=None,
+    )
+    args = parser.parse_args()
+
+    from nexa.gguf import NexaTextInference
+    from output_filter import filter_specific_output
+
+    model_path_text = "Llama3.2-3B-Instruct:q3_K_M"
+    with filter_specific_output():
+        text_inference = NexaTextInference(
+            model_path=model_path_text,
+            local_path=None,
+            stop_words=[],
+            temperature=0.5,
+            max_new_tokens=3000,
+            top_k=3,
+            top_p=0.3,
+            profiling=False,
+        )
+    summaries = summarize_path(args.path, text_inference)
+    if args.output:
+        save_summaries(summaries, args.output)
+    else:
+        for file, summary in summaries.items():
+            print(f"\n=== {file} ===\n{summary}\n")

--- a/forensic_organizer.py
+++ b/forensic_organizer.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+import os
+import shutil
+from typing import Callable, Dict, List
+
+from file_utils import collect_file_paths, read_file_data
+from file_summarizer import summarize_files
+from smart_filename import generate_smart_filename
+
+
+class ForensicOrganizer:
+    """Advanced file organizer that categorizes and renames files."""
+
+    def __init__(
+        self,
+        sorted_dir: str,
+        classifier: Callable[[str], str],
+        summarizer,
+    ) -> None:
+        self.sorted_dir = sorted_dir
+        self.classifier = classifier
+        self.summarizer = summarizer
+
+    def organize_directory(self, directory: str) -> Dict[str, str]:
+        """Organize files in ``directory`` and return summaries."""
+        file_paths = collect_file_paths(directory)
+        summaries: Dict[str, str] = {}
+        for path in file_paths:
+            content = read_file_data(path) or ""
+            category = self.classifier(content)
+            snippet = content[:30].replace("\n", " ")
+            new_name = generate_smart_filename(
+                os.path.basename(path), category, snippet
+            )
+            dest_dir = os.path.join(self.sorted_dir, category)
+            os.makedirs(dest_dir, exist_ok=True)
+            dest_path = os.path.join(dest_dir, new_name)
+            shutil.move(path, dest_path)
+            summaries[dest_path] = content
+        if summaries:
+            summaries = summarize_files(list(summaries.keys()), self.summarizer)
+        return summaries
+
+
+if __name__ == "__main__":
+    import argparse
+    from file_organizer import classify_document
+    from nexa.gguf import NexaTextInference
+    from output_filter import filter_specific_output
+
+    parser = argparse.ArgumentParser(description="Forensic file organizer")
+    parser.add_argument("source", help="Directory with files to organize")
+    parser.add_argument(
+        "--dest", default="Sorted_Files", help="Destination base directory"
+    )
+    args = parser.parse_args()
+
+    with filter_specific_output():
+        text_inference = NexaTextInference(
+            model_path="Llama3.2-3B-Instruct:q3_K_M",
+            local_path=None,
+            stop_words=[],
+            temperature=0.5,
+            max_new_tokens=3000,
+            top_k=3,
+            top_p=0.3,
+            profiling=False,
+        )
+
+    organizer = ForensicOrganizer(args.dest, classify_document, text_inference)
+    summaries = organizer.organize_directory(args.source)
+    for path, summary in summaries.items():
+        print(f"\n=== {path} ===\n{summary}\n")

--- a/tests/test_forensic_organizer.py
+++ b/tests/test_forensic_organizer.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import shutil
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from forensic_organizer import ForensicOrganizer
+
+
+class DummyInference:
+    def create_completion(self, prompt):
+        return {"choices": [{"text": "summary"}]}
+
+
+def dummy_classifier(_text: str) -> str:
+    return "TestCat"
+
+
+class TestForensicOrganizer(unittest.TestCase):
+    def setUp(self):
+        self.src = "temp_in"
+        os.makedirs(self.src, exist_ok=True)
+        with open(os.path.join(self.src, "file.txt"), "w") as f:
+            f.write("content")
+        self.dest = "temp_out"
+        self.org = ForensicOrganizer(self.dest, dummy_classifier, DummyInference())
+
+    def tearDown(self):
+        shutil.rmtree(self.src, ignore_errors=True)
+        shutil.rmtree(self.dest, ignore_errors=True)
+
+    def test_organize_directory(self):
+        summaries = self.org.organize_directory(self.src)
+        cat_dir = os.path.join(self.dest, "TestCat")
+        self.assertTrue(os.path.isdir(cat_dir))
+        self.assertEqual(len(os.listdir(cat_dir)), 1)
+        self.assertTrue(all(path.startswith(cat_dir) for path in summaries))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+)  # noqa: E402
+from file_summarizer import (  # noqa: E402
+    summarize_files,
+    summarize_path,
+    save_summaries,
+)  # noqa: E402
+
+
+class FakeInference:
+    def create_completion(self, prompt):
+        return {"choices": [{"text": "test summary"}]}
+
+
+class TestSummarizer(unittest.TestCase):
+    def test_summarize_files(self):
+        test_file = "sample_test.txt"
+        with open(test_file, "w") as f:
+            f.write("This is a sample text file. It has two sentences.")
+
+        summaries = summarize_files([test_file], FakeInference())
+        self.assertIn(test_file, summaries)
+        self.assertEqual(summaries[test_file], "test summary")
+
+        summaries2 = summarize_path(test_file, FakeInference())
+        self.assertIn(test_file, summaries2)
+        self.assertEqual(summaries2[test_file], "test summary")
+
+        os.remove(test_file)
+
+    def test_summarize_path_directory(self):
+        test_dir = "sample_dir"
+        os.makedirs(test_dir, exist_ok=True)
+        file1 = os.path.join(test_dir, "file1.txt")
+        file2 = os.path.join(test_dir, "file2.txt")
+        with open(file1, "w") as f:
+            f.write("Content of file one.")
+        with open(file2, "w") as f:
+            f.write("Content of file two.")
+
+        summaries = summarize_path(test_dir, FakeInference())
+        self.assertIn(file1, summaries)
+        self.assertIn(file2, summaries)
+
+        os.remove(file1)
+        os.remove(file2)
+        os.rmdir(test_dir)
+
+    def test_save_summaries(self):
+        summaries = {"a.txt": "text"}
+        output = "out.json"
+        save_summaries(summaries, output)
+        with open(output) as f:
+            data = f.read()
+        self.assertIn("a.txt", data)
+        os.remove(output)
+
+    def test_summarize_path_missing(self):
+        with self.assertRaises(FileNotFoundError):
+            summarize_path("nonexistent.txt", FakeInference())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create `ForensicOrganizer` for advanced classification, renaming and summarizing
- add CLI entrypoint for batch organizing directories
- add unit tests covering the new organizer

## Testing
- `black forensic_organizer.py tests/test_forensic_organizer.py`
- `flake8 forensic_organizer.py tests/test_forensic_organizer.py`
- `pytest -o addopts='' tests/test_forensic_organizer.py tests/test_summarizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68526bc9fbe88333913b9a0558d363fc

## Summary by Sourcery

Add forensic file organizing and summarization capabilities with CLI tools and unit tests.

New Features:
- Introduce ForensicOrganizer class to classify, rename, and summarize files into categorized directories
- Add file_summarizer module and CLI for batch summarization of text files

Tests:
- Add unit tests for file_summarizer functionality and error handling
- Add unit test for ForensicOrganizer to validate classification, renaming, and directory organization

Chores:
- Provide data_processing_common module consolidating shared utilities